### PR TITLE
realtime file watching started

### DIFF
--- a/drive-server/main.go
+++ b/drive-server/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -73,6 +74,8 @@ func (ai *addressInfo) ConnectionString() string {
 	return fmt.Sprintf("%s:%s", ai.host, ai.port)
 }
 
+type fileWatchInfo map[string]interface{}
+
 func main() {
 	if envKeySet.PublicKey == "" {
 		errorPrint("publicKey not set. Please set %s in your env.\n", envKeyAlias.PubKeyAlias)
@@ -87,9 +90,13 @@ func main() {
 	m := martini.Classic()
 
 	m.Get("/qr", binding.Bind(meddler.Payload{}), presentQRCode)
-	m.Post("/qr", binding.Bind(meddler.Payload{}), presentQRCode)
+	m.Post("/watch-files", binding.Bind(fileWatchInfo{}), handleFileChanges)
 
 	m.RunOnAddr(envAddrInfo.ConnectionString())
+}
+
+func handleFileChanges(fwi fileWatchInfo, res http.ResponseWriter, req *http.Request) {
+	log.Printf("fwi: %#v", fwi)
 }
 
 func presentQRCode(pl meddler.Payload, res http.ResponseWriter, req *http.Request) {

--- a/src/realtime.go
+++ b/src/realtime.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	uuid "github.com/odeke-em/go-uuid"
+
+	drive "google.golang.org/api/drive/v2"
+)
+
+type Watch struct {
+	Cancel       chan<- struct{}
+	ResponseChan chan *WatchResponse
+	Filepath     string
+	File         *File
+}
+
+type WatchChannel drive.Channel
+
+func (c *Commands) FileWatch(wreq *WatchChannel) (map[string]*Watch, error) {
+	watchesMapping := make(map[string]*Watch)
+
+	// cleanUp is invoked when we encounter errors.
+	cleanUp := func() error {
+		for _, watch := range watchesMapping {
+			watch.Cancel <- struct{}{}
+		}
+
+		// Now explicitly set it to nil to discard any content.
+		watchesMapping = nil
+		return nil
+	}
+
+	for _, relToRootPath := range c.opts.Sources {
+		f, err := c.rem.FindByPath(relToRootPath)
+		if err != nil {
+			if err == ErrPathNotExists {
+				// non-existent files are excusible
+				continue
+			}
+			cleanUp()
+			return nil, err
+		}
+
+		castReq := drive.Channel(*wreq)
+		if castReq.Id == "" {
+			castReq.Id = uuid.NewRandom().String()
+		}
+
+		// Otherwise now let's set up this fileId for watching
+		cancel := make(chan struct{})
+		wreq := &WatchRequest{
+			FileId:  f.Id,
+			Cancel:  cancel,
+			Request: &castReq,
+		}
+
+		reschan, err := c.rem.watchForChanges(wreq)
+		if err != nil {
+			cleanUp()
+			return nil, err
+		}
+
+		watchesMapping[f.Id] = &Watch{
+			Cancel:   cancel,
+			File:     f,
+			Filepath: relToRootPath,
+
+			ResponseChan: reschan,
+		}
+	}
+
+	return watchesMapping, nil
+}


### PR DESCRIPTION
Adding the ability to get realtime changes on files
for the purpose of push-notification/webhook style
watching and for folks to be able to implement sync
clients without trying too hard.

Work in progress:
* Need to ask some Google Drive platform folks what the various
Channel types are. I've currently found `web_hook` but that
requires registration by the user.
* If there is a persistent connection that
pushes notifications say over HTTP2, let's use that instead of
having to hop over web hooks.
* Actually we can do changeList retrieval but we'll have to
implement polling AFAIK unless there is some magic sauce
as point 2) is hopeful about.